### PR TITLE
usage of docker based d compilers; split up dmd and ldc arguments

### DIFF
--- a/awk/prog.sh
+++ b/awk/prog.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+awk -F, '{s+=$2; n+=1}END{print "SUM: ", s, "MEAN: ", s/n}'

--- a/bench/src/lib.rs
+++ b/bench/src/lib.rs
@@ -32,6 +32,11 @@ fn d_ldc(b: &mut Bencher) {
 }
 
 #[bench]
+fn awk(b: &mut Bencher) {
+    b.iter(|| { run("../awk/prog.sh"); })
+}
+
+#[bench]
 fn rust(b: &mut Bencher) {
     b.iter(|| { run("../rust/target/release/rust"); })
 }

--- a/run.sh
+++ b/run.sh
@@ -14,15 +14,20 @@ print_filesize "./rust/target/release/rust"
 echo
 
 echo "Building D (dmd) version..."
-docker run -ti dlanguage/dmd dmd --version
+docker run -ti dlanguage/dmd dmd --version | head -n 1
 ( cd d; docker run -v $(pwd):/work -w /work dlanguage/dmd dmd -O -release -inline -of=prog_dmd prog.d )
 print_filesize "d/prog_dmd"
 echo
 
 echo "Building D (ldc) version..."
-docker run -ti dlanguage/ldc ldc2 --version
+docker run -ti dlanguage/ldc ldc2 --version | head -n 1
 ( cd d; docker run -v $(pwd):/work -w /work dlanguage/ldc ldc2 -O3 -release -of=prog_ldc prog.d )
 print_filesize "d/prog_ldc"
+echo
+
+echo "Building AWK ^^ version..."
+awk --version | head -n 1
+print_filesize "awk/prog.sh"
 echo
 
 echo "Benching..."

--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 RUST_FLAGS="--release"
-D_FLAGS="-O -release"
 
 function print_filesize {
     size=$(expr $(stat $1 --printf="%s") / 1024)
@@ -15,14 +14,14 @@ print_filesize "./rust/target/release/rust"
 echo
 
 echo "Building D (dmd) version..."
-dmd --version
-( cd d; dmd $D_FLAGS -of=prog_dmd prog.d )
+docker run -ti dlanguage/dmd dmd --version
+( cd d; docker run -v $(pwd):/work -w /work dlanguage/dmd dmd -O -release -inline -of=prog_dmd prog.d )
 print_filesize "d/prog_dmd"
 echo
 
 echo "Building D (ldc) version..."
-ldc --version
-( cd d; ldc $D_FLAGS -of=prog_ldc prog.d )
+docker run -ti dlanguage/ldc ldc2 --version
+( cd d; docker run -v $(pwd):/work -w /work dlanguage/ldc ldc2 -O3 -release -of=prog_ldc prog.d )
 print_filesize "d/prog_ldc"
 echo
 


### PR DESCRIPTION
ZCB, awesome repo! And thanks for keeping the rust code up to date.

ldc and dmd compiler switches are not similar.
Could you try these ones?

Also that you do not need to install D compilers, I used the docker images for them.

If the docker way is okay, I could try to add some of the other examples as well.

Execution on my machine:
```
$ time cat test.large | ./rust/target/release/rust 
Average 16, Sum: 1035993088

real	0m9.794s
user	0m9.588s
sys	0m0.688s
$ time cat test.large | ./d/prog_ldc 
Average 16, Sum: 1035993088

real	0m5.928s
user	0m5.684s
sys	0m0.896s
```